### PR TITLE
Add keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,7 @@
+TR064	KEYWORD1
+init	KEYWORD2
+action	KEYWORD2
+xmlTakeParam	KEYWORD2
+md5String	KEYWORD2
+byte2hex	KEYWORD2
+arr_len	KEYWORD2


### PR DESCRIPTION
keywords.txt is used for keyword highlighting in the Arduino IDE. This file adds the keywords for this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

Resolves https://github.com/Aypac/Arduino-TR-064-SOAP-Library/issues/10