### PR TITLE
arduino Stream->find, shorten the search timeout this will fix #55

### DIFF
--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -573,6 +573,7 @@ String TR064::byte2hex(byte number){
 /**************************************************************************/
 bool TR064::xmlTakeParam(String (*params)[2], int nParam) {
     WiFiClient * stream = &tr064client;    
+    stream->setTimeout(40);
     while(stream->connected()) {
         if(!http.connected()) {
             deb_println("[TR064][xmlTakeParam] http connection lost", DEBUG_INFO);


### PR DESCRIPTION
parsing the response XML will result in timeout.
maximum milliseconds to wait for stream data, it defaults to 1000 milliseconds.