### PR TITLE
Adds ability to use https with and without rootCa validation (Esp32 only)

### DIFF
--- a/examples/caller/arduino_secrets.h
+++ b/examples/caller/arduino_secrets.h
@@ -12,6 +12,15 @@
 //#define  SECRET_IP  "192.168.178.1"
 #define  SECRET_IP  "fritz.box"
 
+// Zertifikat von FritzBox herunterladen
+
+// Klicken Sie in der Benutzeroberfläche der FRITZ!Box auf "Internet".
+// Klicken Sie im Menü "Internet" auf "Freigaben".
+// Klicken Sie auf die Registerkarte "FRITZ!Box-Dienste".
+// Klicken Sie auf "Zertifikat herunterladen" und speichern Sie die Datei mit dem Zertifikat auf Ihrem Computer.
+// Open the certificate with 'Editor' and add double quotes as can be seen here
+// Each FritzBox can have its specific certificate
+
 const char *myfritzbox_root_ca =
 "-----BEGIN CERTIFICATE-----\n"
 "MIID2DCCAsCgAwIBAgIJAOReByhZW+7gMA0GCSqGSIb3DQEBCwUAMCcxJTAjBgNV\n"

--- a/examples/caller/arduino_secrets.h
+++ b/examples/caller/arduino_secrets.h
@@ -9,4 +9,30 @@
 #define SECRET_FPASS "this_shouldBEaDecentPassword!"
 
 //Die IP-Adresse Ihrer Fritzbox. Ab Werk lautet diese 192.168.178.1.
-#define  SECRET_IP  "192.168.178.1"
+//#define  SECRET_IP  "192.168.178.1"
+#define  SECRET_IP  "fritz.box"
+
+const char *myfritzbox_root_ca =
+"-----BEGIN CERTIFICATE-----\n"
+"MIID2DCCAsCgAwIBAgIJAOReByhZW+7gMA0GCSqGSIb3DQEBCwUAMCcxJTAjBgNV\n"
+"BAMTHGhzbHk5eHh3ODd2bWt5YncubXlmcml0ei5uZXQwHhcNMTkxMDI4MTAyMzE1\n"
+"WhcNMzgwMTE1MTAyMzE1WjAnMSUwIwYDVQQDExxoc2x5OXh4dzg3dm1reWJ3Lm15\n"
+"ZnJpdHoubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuCbT+qAv\n"
+"scEcYZco6Gl9SHzinr3VCLsTCkibcuGt/FdsLLCcdGHfLb2NX9mMBF+BwYRoFuXt\n"
+"HVx6O5FrlvIHDECw+uQ+vfzFMbpm6b1lvgce/8rll/NgCTirwDW6wS9iy7CtAlSm\n"
+"+nqZdoVqZvcWInrckn7n7p/ZdCM2U2hQ1cNZkJtxXvc/aKL9Lutj28J0J6XxJDFC\n"
+"viPKENz6+fd+B5dwhmbfRPABgPTS/mqb2vCzwNNtvhnkvPRskqc6QSckdm3/HIop\n"
+"iKQP/Ao1lnB4V/tDOf7VhTvVok6pA1D2ccJA/HNAYCvw9/fFoKtAxbnVFXI0+Bls\n"
+"UifYdnCcUkqtDwIDAQABo4IBBTCCAQEwHQYDVR0OBBYEFMnzFscyTefQr+dtqMmW\n"
+"vAWi/GfxMFcGA1UdIwRQME6AFMnzFscyTefQr+dtqMmWvAWi/GfxoSukKTAnMSUw\n"
+"IwYDVQQDExxoc2x5OXh4dzg3dm1reWJ3Lm15ZnJpdHoubmV0ggkA5F4HKFlb7uAw\n"
+"DAYDVR0TBAUwAwEB/zB5BgNVHREEcjBwghxoc2x5OXh4dzg3dm1reWJ3Lm15ZnJp\n"
+"dHoubmV0gglmcml0ei5ib3iCDXd3dy5mcml0ei5ib3iCC215ZnJpdHouYm94gg93\n"
+"d3cubXlmcml0ei5ib3iCCWZyaXR6Lm5hc4INd3d3LmZyaXR6Lm5hczANBgkqhkiG\n"
+"9w0BAQsFAAOCAQEAk8nOxqt1SVEK+N9hT3whwt94shwepQFi0k+oBt3QUpm8Z1OV\n"
+"ipQ4ERUSicVGnHTEBXzxbUaEXuyTAYmaKBnyErR6GjNmp5YNPvlIPBJVku/p8412\n"
+"Y2Thn3YLhqpPG4HIkhD0E+tIh98WZbgwtQc7horRPqkaIBaBdRzi0pHJplRQeXPM\n"
+"knj/XioZvpnd3eMsocHBaAOOjzAOToVjFz9yS4woGaVVYFqYnj6KeJ0JOT9aehjv\n"
+"+Zr7KKh3XDhhBF43/TncYKPqm5uOLHlITivzQ8BTH0pPUujQwa0j+szGftuBjjHw\n"
+"xMX1RtE24A1Pi28qtRu/DbA1nbsj4gy4ymh4vA==\n"
+"-----END CERTIFICATE-----";

--- a/examples/caller/caller.ino
+++ b/examples/caller/caller.ino
@@ -136,6 +136,7 @@ void setup() {
 	//     and development to keep it activated.
 	if(Serial) Serial.printf("Initialize TR-064 connection\n\n");
 	connection.init();
+	if(Serial) Serial.printf("Waiting on button press...\n\n");
 }
 
 void loop() {

--- a/examples/caller/caller.ino
+++ b/examples/caller/caller.ino
@@ -47,7 +47,7 @@ char fpass[] = SECRET_FPASS;
 
 char IP[] = SECRET_IP;
 
-// Set transport protocol here
+// Set transport protocol here: (httpsInsec and https only working on Esp32)
 // http (0) means: normal http via port 49000
 // httpsInsec (1) means: https via port 49443 without rootCa validation
 // https (2) means: https via port 49443 with rootCa validation

--- a/examples/caller/caller.ino
+++ b/examples/caller/caller.ino
@@ -22,13 +22,13 @@
 	#include <ESP8266WiFi.h>
 	#include <ESP8266WiFiMulti.h>
 	#include <ESP8266HTTPClient.h>
-	ESP8266WiFiMulti WiFiMulti;
+	ESP8266WiFiMulti wiFiMulti;
 #elif defined(ESP32)
 	//Imports for ESP32
 	#include <WiFi.h>
 	#include <WiFiMulti.h>
 	#include <HTTPClient.h>
-	WiFiMulti WiFiMulti;
+	WiFiMulti wiFiMulti;
 #endif
 
 #include <tr064.h>
@@ -62,10 +62,14 @@ char IP[] = SECRET_IP;
 // Initializations. No need to change these.
 //-------------------------------------------------------------------------------------
 
+X509Certificate myX509Certificate = myfritzbox_root_ca;
+
 #if TRANSPORT_PROTOCOL == 1
     const int PORT = 49443;
+	Protocol protocol = Protocol::useHttps;
 #else
     const int PORT = 49000;
+	Protocol protocol = Protocol::useHttp;
 #endif
 
 // TR-064 connection
@@ -186,9 +190,9 @@ String getStatus() {
  * Makes sure there is a WIFI connection and waits until it is (re-)established.
  */
 void ensureWIFIConnection() {
-	if ((WiFiMulti.run() != WL_CONNECTED)) {
-		WiFiMulti.addAP(wifi_ssid, wifi_password);
-		while ((WiFiMulti.run() != WL_CONNECTED)) {
+	if ((wiFiMulti.run() != WL_CONNECTED)) {
+		wiFiMulti.addAP(wifi_ssid, wifi_password);
+		while ((wiFiMulti.run() != WL_CONNECTED)) {
 			delay(100);
 		}
 	}

--- a/examples/caller/caller.ino
+++ b/examples/caller/caller.ino
@@ -73,10 +73,10 @@ char IP[] = SECRET_IP;
 #else
     const int PORT = 49443;
 	X509Certificate myX509Certificate = myfritzbox_root_ca;
-	#if TRANSPORT_PROTOCOL == 1   	
-		Protocol protocol = Protocol::useHttpsInsec;		
-	#else	
-		Protocol protocol = Protocol::useHttps;		
+	#if TRANSPORT_PROTOCOL == 1 	
+		Protocol protocol = Protocol::useHttpsInsec;
+	#else
+		Protocol protocol = Protocol::useHttps;
 	#endif
 #endif
 

--- a/examples/caller/caller.ino
+++ b/examples/caller/caller.ino
@@ -62,14 +62,17 @@ char IP[] = SECRET_IP;
 // Initializations. No need to change these.
 //-------------------------------------------------------------------------------------
 
-X509Certificate myX509Certificate = myfritzbox_root_ca;
-
-#if TRANSPORT_PROTOCOL == 1
-    const int PORT = 49443;
-	Protocol protocol = Protocol::useHttps;
-#else
-    const int PORT = 49000;
+#if TRANSPORT_PROTOCOL == 0
+	const int PORT = 49000;
 	Protocol protocol = Protocol::useHttp;
+#elseif TRANSPORT_PROTOCOL == 1
+    const int PORT = 49443;
+	Protocol protocol = Protocol::useHttpsInsec;
+	X509Certificate myX509Certificate = NULL;
+#else
+	const int PORT = 49443;
+	Protocol protocol = Protocol::useHttps;
+	X509Certificate myX509Certificate = myfritzbox_root_ca;
 #endif
 
 // TR-064 connection

--- a/examples/caller/caller.ino
+++ b/examples/caller/caller.ino
@@ -48,8 +48,13 @@ char fpass[] = SECRET_FPASS;
 char IP[] = SECRET_IP;
 
 // Set transport protocol here
-//#define TRANSPORT_PROTOCOL 1    // 0 = http, 1 = https
-#define TRANSPORT_PROTOCOL 0    // 0 = http, 1 = https
+// http (0) means: normal http via port 49000
+// httpsInsec (1) means: https via port 49443 without rootCa validation
+// https (2) means: https via port 49443 with rootCa validation
+
+#define TRANSPORT_PROTOCOL 0    // 0 = http, 1 = httpsInsec, 2 = https
+//#define TRANSPORT_PROTOCOL 1      // 0 = http, 1 = httpsInsec, 2 = https
+//#define TRANSPORT_PROTOCOL 2      // 0 = http, 1 = httpsInsec, 2 = https
 
 //-------------------------------------------------------------------------------------
 // Hardware settings
@@ -65,21 +70,21 @@ char IP[] = SECRET_IP;
 #if TRANSPORT_PROTOCOL == 0
 	const int PORT = 49000;
 	Protocol protocol = Protocol::useHttp;
-#elseif TRANSPORT_PROTOCOL == 1
-    const int PORT = 49443;
-	Protocol protocol = Protocol::useHttpsInsec;
-	X509Certificate myX509Certificate = NULL;
 #else
-	const int PORT = 49443;
-	Protocol protocol = Protocol::useHttps;
+    const int PORT = 49443;
 	X509Certificate myX509Certificate = myfritzbox_root_ca;
+	#if TRANSPORT_PROTOCOL == 1   	
+		Protocol protocol = Protocol::useHttpsInsec;		
+	#else	
+		Protocol protocol = Protocol::useHttps;		
+	#endif
 #endif
 
 // TR-064 connection
-#if TRANSPORT_PROTOCOL == 1
-    TR064 connection(PORT, IP, fuser, fpass, protocol, myX509Certificate);
-#else
+#if TRANSPORT_PROTOCOL == 0
     TR064 connection(PORT, IP, fuser, fpass);
+#else
+	TR064 connection(PORT, IP, fuser, fpass, protocol, myX509Certificate);
 #endif
 
 // -------------------------------------------------------------------------------------

--- a/examples/caller/caller.ino
+++ b/examples/caller/caller.ino
@@ -13,7 +13,7 @@
  *  Please adjust your data below.
  *  
  *  created on: 07.06.2017
- *  latest update: 18.06.2021
+ *  latest update: 22.02.2022
  */
 
 #include <Arduino.h>
@@ -46,7 +46,10 @@ char fuser[] = SECRET_FUSER;
 char fpass[] = SECRET_FPASS;
 
 char IP[] = SECRET_IP;
-int PORT = 49000;
+
+// Set transport protocol here
+//#define TRANSPORT_PROTOCOL 1    // 0 = http, 1 = https
+#define TRANSPORT_PROTOCOL 0    // 0 = http, 1 = https
 
 //-------------------------------------------------------------------------------------
 // Hardware settings
@@ -59,14 +62,30 @@ int PORT = 49000;
 // Initializations. No need to change these.
 //-------------------------------------------------------------------------------------
 
+#if TRANSPORT_PROTOCOL == 1
+    const int PORT = 49443;
+#else
+    const int PORT = 49000;
+#endif
+
 // TR-064 connection
-TR064 connection(PORT, IP, fuser, fpass);
+#if TRANSPORT_PROTOCOL == 1
+    TR064 connection(PORT, IP, fuser, fpass, protocol, myX509Certificate);
+#else
+    TR064 connection(PORT, IP, fuser, fpass);
+#endif
 
 // -------------------------------------------------------------------------------------
 
 //###########################################################################################
 //############################ OKAY, LET'S DO THIS! #########################################
 //###########################################################################################
+
+// forward declarations needed for PlatformIO IDE
+void callWahlhilfe();
+void callDect();
+String getStatus();
+void ensureWIFIConnection();
 
 void setup() {
 	// Start the serial connection

--- a/examples/home-indicator/arduino_secrets.h
+++ b/examples/home-indicator/arduino_secrets.h
@@ -9,4 +9,39 @@
 #define SECRET_FPASS "this_shouldBEaDecentPassword!"
 
 //Die IP-Adresse Ihrer Fritzbox. Ab Werk lautet diese 192.168.178.1.
-#define  SECRET_IP  "192.168.178.1"
+//#define  SECRET_IP  "192.168.178.1"
+#define  SECRET_IP  "fritz.box"
+
+// Zertifikat von FritzBox herunterladen
+
+// Klicken Sie in der Benutzeroberfläche der FRITZ!Box auf "Internet".
+// Klicken Sie im Menü "Internet" auf "Freigaben".
+// Klicken Sie auf die Registerkarte "FRITZ!Box-Dienste".
+// Klicken Sie auf "Zertifikat herunterladen" und speichern Sie die Datei mit dem Zertifikat auf Ihrem Computer.
+// Open the certificate with 'Editor' and add double quotes as can be seen here
+// Each FritzBox can have its specific certificate
+
+const char *myfritzbox_root_ca =
+"-----BEGIN CERTIFICATE-----\n"
+"MIID2DCCAsCgAwIBAgIJAOReByhZW+7gMA0GCSqGSIb3DQEBCwUAMCcxJTAjBgNV\n"
+"BAMTHGhzbHk5eHh3ODd2bWt5YncubXlmcml0ei5uZXQwHhcNMTkxMDI4MTAyMzE1\n"
+"WhcNMzgwMTE1MTAyMzE1WjAnMSUwIwYDVQQDExxoc2x5OXh4dzg3dm1reWJ3Lm15\n"
+"ZnJpdHoubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuCbT+qAv\n"
+"scEcYZco6Gl9SHzinr3VCLsTCkibcuGt/FdsLLCcdGHfLb2NX9mMBF+BwYRoFuXt\n"
+"HVx6O5FrlvIHDECw+uQ+vfzFMbpm6b1lvgce/8rll/NgCTirwDW6wS9iy7CtAlSm\n"
+"+nqZdoVqZvcWInrckn7n7p/ZdCM2U2hQ1cNZkJtxXvc/aKL9Lutj28J0J6XxJDFC\n"
+"viPKENz6+fd+B5dwhmbfRPABgPTS/mqb2vCzwNNtvhnkvPRskqc6QSckdm3/HIop\n"
+"iKQP/Ao1lnB4V/tDOf7VhTvVok6pA1D2ccJA/HNAYCvw9/fFoKtAxbnVFXI0+Bls\n"
+"UifYdnCcUkqtDwIDAQABo4IBBTCCAQEwHQYDVR0OBBYEFMnzFscyTefQr+dtqMmW\n"
+"vAWi/GfxMFcGA1UdIwRQME6AFMnzFscyTefQr+dtqMmWvAWi/GfxoSukKTAnMSUw\n"
+"IwYDVQQDExxoc2x5OXh4dzg3dm1reWJ3Lm15ZnJpdHoubmV0ggkA5F4HKFlb7uAw\n"
+"DAYDVR0TBAUwAwEB/zB5BgNVHREEcjBwghxoc2x5OXh4dzg3dm1reWJ3Lm15ZnJp\n"
+"dHoubmV0gglmcml0ei5ib3iCDXd3dy5mcml0ei5ib3iCC215ZnJpdHouYm94gg93\n"
+"d3cubXlmcml0ei5ib3iCCWZyaXR6Lm5hc4INd3d3LmZyaXR6Lm5hczANBgkqhkiG\n"
+"9w0BAQsFAAOCAQEAk8nOxqt1SVEK+N9hT3whwt94shwepQFi0k+oBt3QUpm8Z1OV\n"
+"ipQ4ERUSicVGnHTEBXzxbUaEXuyTAYmaKBnyErR6GjNmp5YNPvlIPBJVku/p8412\n"
+"Y2Thn3YLhqpPG4HIkhD0E+tIh98WZbgwtQc7horRPqkaIBaBdRzi0pHJplRQeXPM\n"
+"knj/XioZvpnd3eMsocHBaAOOjzAOToVjFz9yS4woGaVVYFqYnj6KeJ0JOT9aehjv\n"
+"+Zr7KKh3XDhhBF43/TncYKPqm5uOLHlITivzQ8BTH0pPUujQwa0j+szGftuBjjHw\n"
+"xMX1RtE24A1Pi28qtRu/DbA1nbsj4gy4ymh4vA==\n"
+"-----END CERTIFICATE-----";

--- a/examples/home-indicator/home-indicator.ino
+++ b/examples/home-indicator/home-indicator.ino
@@ -318,7 +318,7 @@ void getStatusOfMAC(String mac, String (&r)[4][2]) {
 	//Ask for one specific device
 	String params[][2] = {{"NewMACAddress", mac}};
 	String req[][2] = {{"NewIPAddress", ""}, {"NewActive", ""}, {"NewHostName", ""}};
-	if(connection.action("Hosts:1", "GetSpecificHostEntry", params, 1, req, 2)){
+	if(connection.action("Hosts:1", "GetSpecificHostEntry", params, 1, req, 3)){
 		if(Serial) {
 			Serial.println(mac + " is online " + (req[1][1]));
 			Serial.flush();

--- a/examples/home-indicator/home-indicator.ino
+++ b/examples/home-indicator/home-indicator.ino
@@ -42,7 +42,7 @@ char fpass[] = SECRET_FPASS;
 
 char IP[] = SECRET_IP;
 
-// Set transport protocol here
+// Set transport protocol here: (httpsInsec and https only working on Esp32)
 // http (0) means: normal http via port 49000
 // httpsInsec (1) means: https via port 49443 without rootCa validation
 // https (2) means: https via port 49443 with rootCa validation

--- a/examples/home-indicator/home-indicator.ino
+++ b/examples/home-indicator/home-indicator.ino
@@ -47,8 +47,8 @@ char IP[] = SECRET_IP;
 // httpsInsec (1) means: https via port 49443 without rootCa validation
 // https (2) means: https via port 49443 with rootCa validation
 
-//#define TRANSPORT_PROTOCOL 0    // 0 = http, 1 = httpsInsec, 2 = https
-#define TRANSPORT_PROTOCOL 1      // 0 = http, 1 = httpsInsec, 2 = https
+#define TRANSPORT_PROTOCOL 0    // 0 = http, 1 = httpsInsec, 2 = https
+//#define TRANSPORT_PROTOCOL 1      // 0 = http, 1 = httpsInsec, 2 = https
 //#define TRANSPORT_PROTOCOL 2      // 0 = http, 1 = httpsInsec, 2 = https
 
 //-------------------------------------------------------------------------------------

--- a/examples/home-indicator/home-indicator.ino
+++ b/examples/home-indicator/home-indicator.ino
@@ -7,7 +7,7 @@
  *  Please adjust your data below.
  *  
  *  Created on: 09.12.2015,
- *  latest update: 24.06.2021
+ *  latest update: 22.02.2022
  *
  */
 
@@ -91,10 +91,10 @@ int userPins[numUser] = {5, 4, 0}; //Three LED's because there are three users
 #else
     const int PORT = 49443;
 	X509Certificate myX509Certificate = myfritzbox_root_ca;
-	#if TRANSPORT_PROTOCOL == 1   	
-		Protocol protocol = Protocol::useHttpsInsec;		
-	#else	
-		Protocol protocol = Protocol::useHttps;		
+	#if TRANSPORT_PROTOCOL == 1
+		Protocol protocol = Protocol::useHttpsInsec;
+	#else
+		Protocol protocol = Protocol::useHttps;
 	#endif
 #endif
 

--- a/examples/home-indicator/home-indicator.ino
+++ b/examples/home-indicator/home-indicator.ino
@@ -42,17 +42,14 @@ char fpass[] = SECRET_FPASS;
 
 char IP[] = SECRET_IP;
 
-/*
 // Set transport protocol here
-//#define TRANSPORT_PROTOCOL 1    // 0 = http, 1 = https without rootCa validation
-#define TRANSPORT_PROTOCOL 0    // 0 = http, 1 = https
-*/
+// http (0) means: normal http via port 49000
+// httpsInsec (1) means: https via port 49443 without rootCa validation
+// https (2) means: https via port 49443 with rootCa validation
 
-// Select transport protocol here:
-
-Protocol protocol = Protocol::useHttp;			// http
-// Protocol protocol = Protocol::useHttpsInsec; // https without rootCa validation
-// Protocol protocol = Protocol::useHttps;      // https
+//#define TRANSPORT_PROTOCOL 0    // 0 = http, 1 = httpsInsec, 2 = https
+#define TRANSPORT_PROTOCOL 1      // 0 = http, 1 = httpsInsec, 2 = https
+//#define TRANSPORT_PROTOCOL 2      // 0 = http, 1 = httpsInsec, 2 = https
 
 //-------------------------------------------------------------------------------------
 // Put the settings for the devices to detect here
@@ -88,54 +85,24 @@ int userPins[numUser] = {5, 4, 0}; //Three LED's because there are three users
 // Initializations. No need to change these.
 //-------------------------------------------------------------------------------------
 
-int PORT = 49443;
-X509Certificate myX509Certificate = NULL;
-if protocol == Protocol::useHttp
-{
-	Port = 49000;
-}
-else
-{
-	Port = 49443;
-	if (protocol == Protocol::useHttp)
-	{
-		myX509Certificate = myfritzbox_root_ca;
-	}
-}
-
-/*
 #if TRANSPORT_PROTOCOL == 0
 	const int PORT = 49000;
 	Protocol protocol = Protocol::useHttp;
-#elseif TRANSPORT_PROTOCOL == 1
+#else
     const int PORT = 49443;
-	Protocol protocol = Protocol::useHttpsInsec;
-	X509Certificate myX509Certificate = NULL;
-#else
-	const int PORT = 49443;
-	Protocol protocol = Protocol::useHttps;
 	X509Certificate myX509Certificate = myfritzbox_root_ca;
+	#if TRANSPORT_PROTOCOL == 1   	
+		Protocol protocol = Protocol::useHttpsInsec;		
+	#else	
+		Protocol protocol = Protocol::useHttps;		
+	#endif
 #endif
-*/
 
-// TR-064 connection
-TR064 connection();
-if (protocol == Protocol::useHttp)
-{
-	connection = connection((PORT, IP, fuser, fpass);
-}
-else
-{
-	connection = connection(PORT, IP, fuser, fpass, protocol, myX509Certificate);
-}
-
-/*
-#if TRANSPORT_PROTOCOL == 1
-    TR064 connection(PORT, IP, fuser, fpass, protocol, myX509Certificate);
-#else
+#if TRANSPORT_PROTOCOL == 0
     TR064 connection(PORT, IP, fuser, fpass);
+#else
+	TR064 connection(PORT, IP, fuser, fpass, protocol, myX509Certificate);
 #endif
-*/
 
 // Status array. 
 bool onlineUsers[numUser];

--- a/examples/home-indicator/home-indicator.ino
+++ b/examples/home-indicator/home-indicator.ino
@@ -80,12 +80,17 @@ int userPins[numUser] = {5, 4, 0}; //Three LED's because there are three users
 // Initializations. No need to change these.
 //-------------------------------------------------------------------------------------
 
-#if TRANSPORT_PROTOCOL == 1
-    const int PORT = 49443;
-	Protocol protocol = Protocol::useHttps;
-#else
-    const int PORT = 49000;
+#if TRANSPORT_PROTOCOL == 0
+	const int PORT = 49000;
 	Protocol protocol = Protocol::useHttp;
+#elseif TRANSPORT_PROTOCOL == 1
+    const int PORT = 49443;
+	Protocol protocol = Protocol::useHttpsInsec;
+	X509Certificate myX509Certificate = NULL;
+#else
+	const int PORT = 49443;
+	Protocol protocol = Protocol::useHttps;
+	X509Certificate myX509Certificate = myfritzbox_root_ca;
 #endif
 
 // TR-064 connection

--- a/examples/home-indicator/home-indicator.ino
+++ b/examples/home-indicator/home-indicator.ino
@@ -42,9 +42,17 @@ char fpass[] = SECRET_FPASS;
 
 char IP[] = SECRET_IP;
 
+/*
 // Set transport protocol here
-//#define TRANSPORT_PROTOCOL 1    // 0 = http, 1 = https
+//#define TRANSPORT_PROTOCOL 1    // 0 = http, 1 = https without rootCa validation
 #define TRANSPORT_PROTOCOL 0    // 0 = http, 1 = https
+*/
+
+// Select transport protocol here:
+
+Protocol protocol = Protocol::useHttp;			// http
+// Protocol protocol = Protocol::useHttpsInsec; // https without rootCa validation
+// Protocol protocol = Protocol::useHttps;      // https
 
 //-------------------------------------------------------------------------------------
 // Put the settings for the devices to detect here
@@ -80,6 +88,22 @@ int userPins[numUser] = {5, 4, 0}; //Three LED's because there are three users
 // Initializations. No need to change these.
 //-------------------------------------------------------------------------------------
 
+int PORT = 49443;
+X509Certificate myX509Certificate = NULL;
+if protocol == Protocol::useHttp
+{
+	Port = 49000;
+}
+else
+{
+	Port = 49443;
+	if (protocol == Protocol::useHttp)
+	{
+		myX509Certificate = myfritzbox_root_ca;
+	}
+}
+
+/*
 #if TRANSPORT_PROTOCOL == 0
 	const int PORT = 49000;
 	Protocol protocol = Protocol::useHttp;
@@ -92,13 +116,26 @@ int userPins[numUser] = {5, 4, 0}; //Three LED's because there are three users
 	Protocol protocol = Protocol::useHttps;
 	X509Certificate myX509Certificate = myfritzbox_root_ca;
 #endif
+*/
 
 // TR-064 connection
+TR064 connection();
+if (protocol == Protocol::useHttp)
+{
+	connection = connection((PORT, IP, fuser, fpass);
+}
+else
+{
+	connection = connection(PORT, IP, fuser, fpass, protocol, myX509Certificate);
+}
+
+/*
 #if TRANSPORT_PROTOCOL == 1
     TR064 connection(PORT, IP, fuser, fpass, protocol, myX509Certificate);
 #else
     TR064 connection(PORT, IP, fuser, fpass);
 #endif
+*/
 
 // Status array. 
 bool onlineUsers[numUser];

--- a/examples/home-indicator/home-indicator.ino
+++ b/examples/home-indicator/home-indicator.ino
@@ -113,6 +113,16 @@ const int STATUS_HOSTNAME_INDEX = 2;
 //############################ OKAY, LET'S DO THIS! #########################################
 //###########################################################################################
 
+// forward declarations, needed for PlatformIO IDE
+int getWifiNumber();
+void getStatusOfAllWifi();
+void getStatusOfAllWifi(int numDev);
+void getStatusOfMACwifi(String mac, String (&r)[4][2]);
+int getDeviceNumber();
+void getStatusOfMAC(String mac, String (&r)[4][2]);
+void verboseStatus(String r[4][2]);
+void ensureWIFIConnection();
+
 void setup() {
 	// Start the serial connection
 	// Not required for production, but helpful for development.

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -62,10 +62,10 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
     _certificate = certificate;
     _protocol = protocol;
     if (protocol == Protocol::useHttp) {
-        tr064ClientPtr = &tr064SimpleClient;      
+        tr064ClientPtr = &tr064SimpleClient;   
     } else {
-        if (protocol == Protocol::useHttpsInsec) {       
-            tr064SslClient.setInsecure();           
+        if (protocol == Protocol::useHttpsInsec) {    
+            tr064SslClient.setInsecure();   
         } else {
             tr064SslClient.setCACert(certificate);
         }
@@ -125,10 +125,10 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
     _certificate = certificate;
     _protocol = protocol;
     if (protocol == Protocol::useHttp) {
-        tr064ClientPtr = &tr064SimpleClient;      
+        tr064ClientPtr = &tr064SimpleClient;     
     } else {
         if (protocol == Protocol::useHttpsInsec) {       
-            tr064SslClient.setInsecure();           
+            tr064SslClient.setInsecure();         
         } else {
             tr064SslClient.setCACert(certificate);
         }

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -61,14 +61,21 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
     this->_state = TR064_NO_SERVICES;
     _certificate = certificate;
     _protocol = protocol;
-    if (protocol == Protocol::useHttps)
+    if (protocol == Protocol::useHtt)
     {
-        tr064SslClient.setCACert(certificate); 
-        tr064ClientPtr = &tr064SslClient;
+        tr064ClientPtr = &tr064SimpleClient;      
     }
     else
     {
-        tr064ClientPtr = &tr064SimpleClient;
+        if (protocol == Protocol::useHttpsInsec)
+        {       
+            tr064SslClient.setInsecure();           
+        }
+        else
+        {
+            tr064SslClient.setCACert(certificate);
+        }
+        tr064ClientPtr = &tr064SslClient;
     }
 }
 
@@ -495,11 +502,11 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
     deb_println("[HTTP] prepare request to URL: " + protocolPrefix + _ip + ":" + _port + url, DEBUG_INFO);
     http.setReuse(true);
 
-    if (_protocol == Protocol::useHttps) {
+    if (_protocol == Protocol::useHtt) {
+        http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);
+    }else{
         http.begin(tr064SslClient, _ip.c_str(), _port, url.c_str(), useTls);
         http.setConnectTimeout(2000);
-    }else{
-        http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);
     }
     
     if (soapaction != "") {

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -131,7 +131,7 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
     else
     {
         tr064ClientPtr = &tr064SimpleClient;
-    }
+    
     return *this;
 }
 
@@ -147,8 +147,7 @@ void TR064::initServiceURLs() {
      */
 
     _state = TR064_NO_SERVICES;
-    if(httpRequest(_detectPage, "", "", true))
-        {
+    if(httpRequest(_detectPage, "", "", true)) {
             deb_println("[TR064][initServiceURLs] get the Stream ", DEBUG_INFO);
             int i = 0;
             while(1) {

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -67,7 +67,7 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
         if (protocol == Protocol::useHttpsInsec) {
             tr064SslClient.setInsecure();
         } else {
-            #if defined(Esp32)
+            #if defined(ESP32)
             tr064SslClient.setCACert(certificate);
             #endif
         }
@@ -132,7 +132,7 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
         if (protocol == Protocol::useHttpsInsec) {    
             tr064SslClient.setInsecure();    
         } else {
-            #if defined(Esp32)
+            #if defined(ESP32)
             tr064SslClient.setCACert(certificate);
             #endif
         }
@@ -505,7 +505,7 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
         http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);
     }else{
         http.begin(tr064SslClient, _ip.c_str(), _port, url.c_str(), useTls);
-        #if defined(Esp32)
+        #if defined(ESP32)
         http.setConnectTimeout(2000);
         #endif
     }

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -67,7 +67,9 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
         if (protocol == Protocol::useHttpsInsec) {
             tr064SslClient.setInsecure();
         } else {
+            #if defined(Esp32)
             tr064SslClient.setCACert(certificate);
+            #endif
         }
         tr064ClientPtr = &tr064SslClient;
     }
@@ -130,7 +132,9 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
         if (protocol == Protocol::useHttpsInsec) {    
             tr064SslClient.setInsecure();    
         } else {
+            #if defined(Esp32)
             tr064SslClient.setCACert(certificate);
+            #endif
         }
         tr064ClientPtr = &tr064SslClient;
     }
@@ -501,7 +505,9 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
         http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);
     }else{
         http.begin(tr064SslClient, _ip.c_str(), _port, url.c_str(), useTls);
+        #if defined(Esp32)
         http.setConnectTimeout(2000);
+        #endif
     }
     
     if (soapaction != "") {

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -126,7 +126,7 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
     if (protocol == Protocol::useHttps)
     {
         tr064SslClient.setCACert(certificate);
-        tr064ClientPtr = &tr064SslClient;   
+        tr064ClientPtr = &tr064SslClient;
     }
     else
     {
@@ -147,11 +147,11 @@ void TR064::initServiceURLs() {
      */
 
     _state = TR064_NO_SERVICES;
-        if(httpRequest(_detectPage, "", "", true, _protocol))
+    if(httpRequest(_detectPage, "", "", true, _protocol))
         {
             deb_println("[TR064][initServiceURLs] get the Stream ", DEBUG_INFO);
             int i = 0;
-            while(1) {        
+            while(1) {  
                 if(!http.connected()) {
                     deb_println("[TR064][initServiceURLs] xmlTakeParam : http connection lost", DEBUG_INFO);
                     break;                      
@@ -170,9 +170,8 @@ void TR064::initServiceURLs() {
                     break;
                 }
             }            
-            deb_println("[TR064][initServiceURLs] message: reading done", DEBUG_INFO);              
-    } 
-    else {  
+            deb_println("[TR064][initServiceURLs] message: reading done", DEBUG_INFO);       
+    } else {  
         deb_println("[TR064][initServiceURLs]<Error> initServiceUrls failed", DEBUG_ERROR);  
         return;      
     }
@@ -208,7 +207,7 @@ String TR064::generateAuthXML() {
 String TR064::generateAuthToken() {
     String token = md5String(_secretH + ":" + _nonce);
     deb_println("[TR064][generateAuthToken] The auth token is '" + token + "'", DEBUG_INFO);
-    return token; 
+    return token;
 }
 
 /**************************************************************************/
@@ -238,11 +237,10 @@ bool TR064::action(const String& service, const String& act, String params[][2],
     deb_println("[TR064][action] with parameters", DEBUG_VERBOSE);
     String req[][2] = {{}};
     if(action(service, act, params, nParam, req, 0, url)){
-  
+
         http.end();
         return true;
     }
-
     http.end();    
     return false;
 }
@@ -280,8 +278,7 @@ bool TR064::action(const String& service, const String& act, String params[][2],
     
     int tries = 0; // Keep track on the number of times we tried to request.
     if (action_raw(service, act, params, nParam, url)) {
-        if(xmlTakeParam(req, nReq))
-        {
+        if(xmlTakeParam(req, nReq)){
             deb_println("[TR064][action] extraction complete.", DEBUG_VERBOSE);
         }else{
             return false;
@@ -308,10 +305,10 @@ bool TR064::action(const String& service, const String& act, String params[][2],
                     delay(5000);
                 }
 
-                http.end();      
+                http.end();
             }
             if (tries >= 3) {
-                deb_println("[TR064][action]<error> Giving up the request ", DEBUG_ERROR);               
+                deb_println("[TR064][action]<error> Giving up the request ", DEBUG_ERROR);           
                 http.end();
                 return false;
             }
@@ -483,10 +480,8 @@ String TR064::findServiceURL(const String& service) {
     @param    retry
                 Should the request be repeated with a new nonce, if it fails?
     @param    protocol
-                Transmission protocol to be used (http/https).
-                
-
-    @return The response from the device.
+                Transmission protocol to be used (http/https).             
+    @return success state.
 */
 /**************************************************************************/
 bool TR064::httpRequest(const String& url, const String& xml, const String& soapaction, bool retry, Protocol protocol) {
@@ -494,24 +489,21 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
         deb_println("[TR064][httpRequest] URL is empty, abort http request.", DEBUG_INFO);
         return false;
     }
-    
+
     String protocolPrefix = protocol == Protocol::useHttps ? "https://" : "http://";
     bool useTls = protocol == Protocol::useHttps ? true : false;
 
     deb_println("[HTTP] prepare request to URL: " + protocolPrefix + _ip + ":" + _port + url, DEBUG_INFO);
     http.setReuse(true);
 
-    if (protocol == Protocol::useHttps)
-    {   
+    if (protocol == Protocol::useHttps) {   
         http.begin(tr064SslClient, _ip.c_str(), _port, url.c_str(), useTls);
         http.setConnectTimeout(2000);        
-    }
-    else
-    {
+    }else{
         http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);        
     }
     
-    if (soapaction != "") {  
+    if (soapaction != "") {
         http.addHeader("CONTENT-TYPE", "text/xml"); //; charset=\"utf-8\"
         http.addHeader("SOAPACTION", soapaction);
     }
@@ -520,22 +512,23 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
    
     int httpCode=0;
     if (xml != "") {
-        deb_println("[HTTP] Posting XML:", DEBUG_VERBOSE);
-        deb_println("---------------------------------", DEBUG_VERBOSE);
+        deb_println("[TR064][httpRequest] Posting XML:", DEBUG_INFO);
+        deb_println("[TR064][httpRequest] ---------------------------------", DEBUG_VERBOSE);
         deb_println(xml, DEBUG_VERBOSE);
-        deb_println("---------------------------------\n", DEBUG_VERBOSE);        
+        deb_println("[TR064][httpRequest] ---------------------------------\n", DEBUG_VERBOSE);
+ 
         httpCode = http.POST(xml);
-        deb_println("[HTTP] POST... SOAPACTION: '" + soapaction + "'", DEBUG_VERBOSE);
+        deb_println("[TR064][httpRequest] POST... SOAPACTION: '" + soapaction + "'", DEBUG_VERBOSE);
     } else {         
         httpCode = http.GET();
-        deb_println("[HTTP] GET...", DEBUG_VERBOSE);
+        deb_println("[TR064][httpRequest] GET...", DEBUG_VERBOSE);
     }
 
-    // httpCode will be negative on error  
+    // httpCode will be negative on error 
     if (httpCode > 0) {
         // HTTP header has been sent and Server response header has been handled
-          
-        if (httpCode == HTTP_CODE_OK) {             
+
+        if (httpCode == HTTP_CODE_OK) {
             return true;
         }else{
             if (httpCode == HTTP_CODE_INTERNAL_SERVER_ERROR) { 
@@ -569,10 +562,10 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
             deb_println("[TR064][httpRequest] <Error> Giving up.", DEBUG_ERROR);
             return false;
         }
-    }  
+    }
     return true;
 }
-            
+
 
 /**************************************************************************/
 /*!
@@ -623,24 +616,23 @@ String TR064::byte2hex(byte number){
 */
 /**************************************************************************/
 bool TR064::xmlTakeParam(String (*params)[2], int nParam) {
-    WiFiClient * stream = tr064ClientPtr;
-     
-    while(stream->connected()) {  
+    WiFiClient * stream = tr064ClientPtr;  
+    while(stream->connected()) {
         if(!http.connected()) {
             deb_println("[TR064][xmlTakeParam] http connection lost", DEBUG_INFO);
             return false;                      
-        }        
+        }
         if(stream->find("<")){
             const String htmltag = stream->readStringUntil('>');
             const String value = stream->readStringUntil('<');
             deb_println("[TR064][xmlTakeParam] htmltag: "+htmltag, DEBUG_VERBOSE);
-            
+
             if (nParam > 0) {
                 for (uint16_t i=0; i<nParam; ++i) {
                     if(htmltag.equalsIgnoreCase(params[i][0])){
                         params[i][1] = value; 
                         deb_println("[TR064][action] found requestparameter: "+params[i][0]+" = "+params[i][1], DEBUG_VERBOSE);
-                    }   
+                    }
                 }
             }            
             if(htmltag.equalsIgnoreCase("Nonce")){
@@ -666,11 +658,11 @@ bool TR064::xmlTakeParam(String (*params)[2], int nParam) {
             }
             if(htmltag.equalsIgnoreCase("errorDescription")){
                 deb_println("[TR064][xmlTakeParam] <TR064> Failed, errorDescription: " + value, DEBUG_VERBOSE);
-            }        
+            }
         }else{
             break;    
         }
-        
+
     }
     return true;
 }

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -61,7 +61,7 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
     this->_state = TR064_NO_SERVICES;
     _certificate = certificate;
     _protocol = protocol;
-    if (protocol == Protocol::useHtt) {
+    if (protocol == Protocol::useHttp) {
         tr064ClientPtr = &tr064SimpleClient;      
     } else {
         if (protocol == Protocol::useHttpsInsec) {       
@@ -124,7 +124,7 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
     this->_pass = pass;
     _certificate = certificate;
     _protocol = protocol;
-    if (protocol == Protocol::useHtt) {
+    if (protocol == Protocol::useHttp) {
         tr064ClientPtr = &tr064SimpleClient;      
     } else {
         if (protocol == Protocol::useHttpsInsec) {       
@@ -497,7 +497,7 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
     deb_println("[HTTP] prepare request to URL: " + protocolPrefix + _ip + ":" + _port + url, DEBUG_INFO);
     http.setReuse(true);
 
-    if (_protocol == Protocol::useHtt) {
+    if (_protocol == Protocol::useHttp) {
         http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);
     }else{
         http.begin(tr064SslClient, _ip.c_str(), _port, url.c_str(), useTls);

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -116,7 +116,7 @@ void TR064::init() {
                 X509Certificate of Fritzbox to be used for https transmission.
 */
 /**************************************************************************/
-TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, const String& pass, Protocol protocol, X509Certificate certificate){
+TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, const String& pass, Protocol protocol, X509Certificate certificate) {
     this->_ip = ip;
     this->_port = port;
     this->_user = user;
@@ -131,7 +131,7 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
     else
     {
         tr064ClientPtr = &tr064SimpleClient;
-    
+    }
     return *this;
 }
 
@@ -304,7 +304,6 @@ bool TR064::action(const String& service, const String& act, String params[][2],
                     deb_println("[TR064][action]<Error> Retrying in 5s", DEBUG_ERROR);
                     delay(5000);
                 }
-
                 http.end();
             }
             if (tries >= 3) {
@@ -480,7 +479,7 @@ String TR064::findServiceURL(const String& service) {
     @param    retry
                 Should the request be repeated with a new nonce, if it fails?
     @param    protocol
-                Transmission protocol to be used (http/https). 
+                Transmission protocol to be used (http/https).
     @return success state.
 */
 /**************************************************************************/
@@ -618,6 +617,7 @@ String TR064::byte2hex(byte number){
 /**************************************************************************/
 bool TR064::xmlTakeParam(String (*params)[2], int nParam) {
     WiFiClient * stream = tr064ClientPtr;
+
     while(stream->connected()) {
         if(!http.connected()) {
             deb_println("[TR064][xmlTakeParam] http connection lost", DEBUG_INFO);

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -61,18 +61,12 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
     this->_state = TR064_NO_SERVICES;
     _certificate = certificate;
     _protocol = protocol;
-    if (protocol == Protocol::useHtt)
-    {
+    if (protocol == Protocol::useHtt) {
         tr064ClientPtr = &tr064SimpleClient;      
-    }
-    else
-    {
-        if (protocol == Protocol::useHttpsInsec)
-        {       
+    } else {
+        if (protocol == Protocol::useHttpsInsec) {       
             tr064SslClient.setInsecure();           
-        }
-        else
-        {
+        } else {
             tr064SslClient.setCACert(certificate);
         }
         tr064ClientPtr = &tr064SslClient;
@@ -130,18 +124,12 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
     this->_pass = pass;
     _certificate = certificate;
     _protocol = protocol;
-    if (protocol == Protocol::useHtt)
-    {
+    if (protocol == Protocol::useHtt) {
         tr064ClientPtr = &tr064SimpleClient;      
-    }
-    else
-    {
-        if (protocol == Protocol::useHttpsInsec)
-        {       
+    } else {
+        if (protocol == Protocol::useHttpsInsec) {       
             tr064SslClient.setInsecure();           
-        }
-        else
-        {
+        } else {
             tr064SslClient.setCACert(certificate);
         }
         tr064ClientPtr = &tr064SslClient;
@@ -503,8 +491,8 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
         return false;
     }
 
-    String protocolPrefix = _protocol == Protocol::useHttps ? "https://" : "http://";
-    bool useTls = _protocol == Protocol::useHttps ? true : false;
+    String protocolPrefix = _protocol == Protocol::useHttp ? "http://" : "https://";
+    bool useTls = _protocol == Protocol::useHttp ? false : true;
 
     deb_println("[HTTP] prepare request to URL: " + protocolPrefix + _ip + ":" + _port + url, DEBUG_INFO);
     http.setReuse(true);

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -130,14 +130,21 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
     this->_pass = pass;
     _certificate = certificate;
     _protocol = protocol;
-    if (protocol == Protocol::useHttps)
+    if (protocol == Protocol::useHtt)
     {
-        tr064SslClient.setCACert(certificate);
-        tr064ClientPtr = &tr064SslClient;
+        tr064ClientPtr = &tr064SimpleClient;      
     }
     else
     {
-        tr064ClientPtr = &tr064SimpleClient;
+        if (protocol == Protocol::useHttpsInsec)
+        {       
+            tr064SslClient.setInsecure();           
+        }
+        else
+        {
+            tr064SslClient.setCACert(certificate);
+        }
+        tr064ClientPtr = &tr064SslClient;
     }
     return *this;
 }

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -62,10 +62,10 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
     _certificate = certificate;
     _protocol = protocol;
     if (protocol == Protocol::useHttp) {
-        tr064ClientPtr = &tr064SimpleClient;   
+        tr064ClientPtr = &tr064SimpleClient;
     } else {
-        if (protocol == Protocol::useHttpsInsec) {    
-            tr064SslClient.setInsecure();   
+        if (protocol == Protocol::useHttpsInsec) {
+            tr064SslClient.setInsecure();
         } else {
             tr064SslClient.setCACert(certificate);
         }
@@ -125,10 +125,10 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
     _certificate = certificate;
     _protocol = protocol;
     if (protocol == Protocol::useHttp) {
-        tr064ClientPtr = &tr064SimpleClient;     
+        tr064ClientPtr = &tr064SimpleClient;
     } else {
-        if (protocol == Protocol::useHttpsInsec) {       
-            tr064SslClient.setInsecure();         
+        if (protocol == Protocol::useHttpsInsec) {    
+            tr064SslClient.setInsecure();    
         } else {
             tr064SslClient.setCACert(certificate);
         }

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -52,7 +52,7 @@
                 X509Certificate of Fritzbox to be used for https transmission.
 */
 /**************************************************************************/
-TR064::TR064(uint16_t port, const String& ip, const String& user, const String& pass, Protocol protocol, X509Certificate certificate) { 
+TR064::TR064(uint16_t port, const String& ip, const String& user, const String& pass, Protocol protocol, X509Certificate certificate) {
     _port = port;
     _ip = ip;
     _user = user;
@@ -60,16 +60,16 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
     debug_level = DEBUG_NONE;
     this->_state = TR064_NO_SERVICES;
     _certificate = certificate;
-    _protocol = protocol;  
+    _protocol = protocol;
     if (protocol == Protocol::useHttps)
     {
         tr064SslClient.setCACert(certificate);
-        tr064ClientPtr = &tr064SslClient;       
+        tr064ClientPtr = &tr064SslClient;   
     }
     else
     {
         tr064ClientPtr = &tr064SimpleClient;
-    }  
+    }
 }
 
 /**************************************************************************/
@@ -94,7 +94,7 @@ TR064::TR064() {
 void TR064::init() {
     delay(100); // TODO: REMOVE (after testing, that it still works!)
     // Get a list of all services and the associated urls
-    initServiceURLs();  
+    initServiceURLs();
 }
 
 
@@ -120,13 +120,13 @@ TR064& TR064::setServer(uint16_t port, const String& ip, const String& user, con
     this->_ip = ip;
     this->_port = port;
     this->_user = user;
-    this->_pass = pass; 
+    this->_pass = pass;
     _certificate = certificate;
-    _protocol = protocol;  
+    _protocol = protocol;
     if (protocol == Protocol::useHttps)
     {
         tr064SslClient.setCACert(certificate);
-        tr064ClientPtr = &tr064SslClient;       
+        tr064ClientPtr = &tr064SslClient;   
     }
     else
     {
@@ -146,13 +146,13 @@ void TR064::initServiceURLs() {
      * possibilities of their device(s) - see #9 on Github.
      */
 
-    this->_state = TR064_NO_SERVICES;
+    _state = TR064_NO_SERVICES;
         if(httpRequest(_detectPage, "", "", true, _protocol))
         {
             deb_println("[TR064][initServiceURLs] get the Stream ", DEBUG_INFO);
             int i = 0;
-            while(1) {              
-                if(!http.connected()) {   
+            while(1) {        
+                if(!http.connected()) {
                     deb_println("[TR064][initServiceURLs] xmlTakeParam : http connection lost", DEBUG_INFO);
                     break;                      
                 }
@@ -170,13 +170,13 @@ void TR064::initServiceURLs() {
                     break;
                 }
             }            
-            deb_println("[TR064][initServiceURLs] message: reading done", DEBUG_INFO);                    
+            deb_println("[TR064][initServiceURLs] message: reading done", DEBUG_INFO);              
     } 
     else {  
         deb_println("[TR064][initServiceURLs]<Error> initServiceUrls failed", DEBUG_ERROR);  
         return;      
     }
-    _state = TR064_SERVICES_LOADED;   
+    _state = TR064_SERVICES_LOADED;
     http.end();
 }
 
@@ -207,8 +207,8 @@ String TR064::generateAuthXML() {
 /**************************************************************************/
 String TR064::generateAuthToken() {
     String token = md5String(_secretH + ":" + _nonce);
-    deb_println("The auth token is '" + token + "'", DEBUG_INFO);
-    return token;
+    deb_println("[TR064][generateAuthToken] The auth token is '" + token + "'", DEBUG_INFO);
+    return token; 
 }
 
 /**************************************************************************/
@@ -238,11 +238,11 @@ bool TR064::action(const String& service, const String& act, String params[][2],
     deb_println("[TR064][action] with parameters", DEBUG_VERBOSE);
     String req[][2] = {{}};
     if(action(service, act, params, nParam, req, 0, url)){
-              
+  
         http.end();
         return true;
     }
-      
+
     http.end();    
     return false;
 }
@@ -279,14 +279,11 @@ bool TR064::action(const String& service, const String& act, String params[][2],
     deb_println("[TR064][action] with extraction", DEBUG_VERBOSE);
     
     int tries = 0; // Keep track on the number of times we tried to request.
-    if (action_raw(service, act, params, nParam, url)) 
-    {
+    if (action_raw(service, act, params, nParam, url)) {
         if(xmlTakeParam(req, nReq))
         {
             deb_println("[TR064][action] extraction complete.", DEBUG_VERBOSE);
-        }
-        else
-        {
+        }else{
             return false;
         }
         deb_println("[TR064][action] Response status: "+ _status +", Tries: "+String(tries), DEBUG_INFO);
@@ -299,19 +296,19 @@ bool TR064::action(const String& service, const String& act, String params[][2],
                 String a[][2] = {{"NewAssociatedDeviceIndex", "1"}};
                 String wlanService = "WLANConfiguration:1", deviceInfo="GetGenericAssociatedDeviceInfo";
                 action_raw(wlanService, deviceInfo, a, 1, "/upnp/control/wlanconfig1");
-                             
+
                 if(xmlTakeParam(req, nReq)){
                     deb_println("[TR064][action] extraction complete.", DEBUG_VERBOSE);
                 }
-                
+
                 if (_nonce == "" || _realm == "") {
                     ++tries;
                     deb_println("[TR064][action]<Error> Nonce/realm request not successful!", DEBUG_ERROR);
                     deb_println("[TR064][action]<Error> Retrying in 5s", DEBUG_ERROR);
                     delay(5000);
                 }
-               
-                http.end();             
+
+                http.end();      
             }
             if (tries >= 3) {
                 deb_println("[TR064][action]<error> Giving up the request ", DEBUG_ERROR);               

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -171,6 +171,7 @@ void TR064::initServiceURLs() {
                 }
             }            
             deb_println("[TR064][initServiceURLs] message: reading done", DEBUG_INFO);
+
     } else {  
         deb_println("[TR064][initServiceURLs]<Error> initServiceUrls failed", DEBUG_ERROR);  
         return;      
@@ -308,7 +309,7 @@ bool TR064::action(const String& service, const String& act, String params[][2],
                 http.end();
             }
             if (tries >= 3) {
-                deb_println("[TR064][action]<error> Giving up the request ", DEBUG_ERROR);    
+                deb_println("[TR064][action]<error> Giving up the request ", DEBUG_ERROR);
                 http.end();
                 return false;
             }
@@ -525,9 +526,9 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
     }
 
     // httpCode will be negative on error
-    deb_println("[TR064][httpRequest] Response code: " + String(httpCode), DEBUG_INFO); 
+    deb_println("[TR064][httpRequest] Response code: " + String(httpCode), DEBUG_INFO);
     if (httpCode > 0) {
-        // HTTP header has been sent and Server response header has been handled
+        // HTTP header has been send and Server response header has been handled
 
         if (httpCode == HTTP_CODE_OK) {
             return true;

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -63,7 +63,7 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
     _protocol = protocol;
     if (protocol == Protocol::useHttps)
     {
-        tr064SslClient.setCACert(certificate);
+        tr064SslClient.setCACert(certificate); 
         tr064ClientPtr = &tr064SslClient;
     }
     else

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -365,9 +365,9 @@ bool TR064::action_raw(const String& service, const String& act, String params[]
     
     // Send the http-Request
     if(url !=""){
-        return httpRequest(url, xml, soapaction, true, _protocol);
+        return httpRequest(url, xml, soapaction, true);
     }else{
-        return httpRequest(findServiceURL(_servicePrefix + serviceName), xml, soapaction, true, _protocol);
+        return httpRequest(findServiceURL(_servicePrefix + serviceName), xml, soapaction, true);
     }
 }
 

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -64,7 +64,7 @@ TR064::TR064(uint16_t port, const String& ip, const String& user, const String& 
     if (protocol == Protocol::useHttps)
     {
         tr064SslClient.setCACert(certificate);
-        tr064ClientPtr = &tr064SslClient;   
+        tr064ClientPtr = &tr064SslClient;
     }
     else
     {
@@ -170,7 +170,7 @@ void TR064::initServiceURLs() {
                     break;
                 }
             }            
-            deb_println("[TR064][initServiceURLs] message: reading done", DEBUG_INFO);       
+            deb_println("[TR064][initServiceURLs] message: reading done", DEBUG_INFO);
     } else {  
         deb_println("[TR064][initServiceURLs]<Error> initServiceUrls failed", DEBUG_ERROR);  
         return;      
@@ -308,13 +308,13 @@ bool TR064::action(const String& service, const String& act, String params[][2],
                 http.end();
             }
             if (tries >= 3) {
-                deb_println("[TR064][action]<error> Giving up the request ", DEBUG_ERROR);           
+                deb_println("[TR064][action]<error> Giving up the request ", DEBUG_ERROR);       
                 http.end();
                 return false;
             }
             return action(service, act, params, nParam, req, nReq, url);
         }
-        deb_println("[TR064][action] Done.", DEBUG_INFO);       
+        deb_println("[TR064][action] Done.", DEBUG_INFO);
         http.end();
         return true;
         
@@ -480,7 +480,7 @@ String TR064::findServiceURL(const String& service) {
     @param    retry
                 Should the request be repeated with a new nonce, if it fails?
     @param    protocol
-                Transmission protocol to be used (http/https).             
+                Transmission protocol to be used (http/https).     
     @return success state.
 */
 /**************************************************************************/
@@ -496,20 +496,20 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
     deb_println("[HTTP] prepare request to URL: " + protocolPrefix + _ip + ":" + _port + url, DEBUG_INFO);
     http.setReuse(true);
 
-    if (protocol == Protocol::useHttps) {   
+    if (protocol == Protocol::useHttps) {
         http.begin(tr064SslClient, _ip.c_str(), _port, url.c_str(), useTls);
-        http.setConnectTimeout(2000);        
+        http.setConnectTimeout(2000);  
     }else{
-        http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);        
+        http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);   
     }
     
     if (soapaction != "") {
         http.addHeader("CONTENT-TYPE", "text/xml"); //; charset=\"utf-8\"
         http.addHeader("SOAPACTION", soapaction);
     }
-    
+
     http.addHeader("ACCEPT-ENCODING", "chunked");
-   
+
     int httpCode=0;
     if (xml != "") {
         deb_println("[TR064][httpRequest] Posting XML:", DEBUG_INFO);
@@ -519,12 +519,13 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
  
         httpCode = http.POST(xml);
         deb_println("[TR064][httpRequest] POST... SOAPACTION: '" + soapaction + "'", DEBUG_VERBOSE);
-    } else {         
+    } else { 
         httpCode = http.GET();
         deb_println("[TR064][httpRequest] GET...", DEBUG_VERBOSE);
     }
 
-    // httpCode will be negative on error 
+    // httpCode will be negative on error
+    deb_println("[TR064][httpRequest] Response code: " + String(httpCode), DEBUG_INFO); 
     if (httpCode > 0) {
         // HTTP header has been sent and Server response header has been handled
 
@@ -616,7 +617,7 @@ String TR064::byte2hex(byte number){
 */
 /**************************************************************************/
 bool TR064::xmlTakeParam(String (*params)[2], int nParam) {
-    WiFiClient * stream = tr064ClientPtr;  
+    WiFiClient * stream = tr064ClientPtr;
     while(stream->connected()) {
         if(!http.connected()) {
             deb_println("[TR064][xmlTakeParam] http connection lost", DEBUG_INFO);
@@ -680,11 +681,10 @@ bool TR064::xmlTakeParam(String (*params)[2], int nParam) {
     @return success state.
 */
 /**************************************************************************/
-bool TR064::xmlTakeParam(String& value, const String& needParam) {   
+bool TR064::xmlTakeParam(String& value, const String& needParam) {
     WiFiClient * stream = tr064ClientPtr;
-    
     while(stream->connected()) {       
-        if(!http.connected()) {  
+        if(!http.connected()) {
             deb_println("[TR064][xmlTakeParam] http connection lost", DEBUG_INFO);
             return false;                      
         }

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -151,7 +151,7 @@ void TR064::initServiceURLs() {
         {
             deb_println("[TR064][initServiceURLs] get the Stream ", DEBUG_INFO);
             int i = 0;
-            while(1) {  
+            while(1) {
                 if(!http.connected()) {
                     deb_println("[TR064][initServiceURLs] xmlTakeParam : http connection lost", DEBUG_INFO);
                     break;                      
@@ -308,7 +308,7 @@ bool TR064::action(const String& service, const String& act, String params[][2],
                 http.end();
             }
             if (tries >= 3) {
-                deb_println("[TR064][action]<error> Giving up the request ", DEBUG_ERROR);       
+                deb_println("[TR064][action]<error> Giving up the request ", DEBUG_ERROR);    
                 http.end();
                 return false;
             }
@@ -480,7 +480,7 @@ String TR064::findServiceURL(const String& service) {
     @param    retry
                 Should the request be repeated with a new nonce, if it fails?
     @param    protocol
-                Transmission protocol to be used (http/https).     
+                Transmission protocol to be used (http/https). 
     @return success state.
 */
 /**************************************************************************/
@@ -498,9 +498,9 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
 
     if (protocol == Protocol::useHttps) {
         http.begin(tr064SslClient, _ip.c_str(), _port, url.c_str(), useTls);
-        http.setConnectTimeout(2000);  
+        http.setConnectTimeout(2000);
     }else{
-        http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);   
+        http.begin(tr064SimpleClient, _ip.c_str(), _port, url.c_str(), useTls);
     }
     
     if (soapaction != "") {
@@ -516,10 +516,10 @@ bool TR064::httpRequest(const String& url, const String& xml, const String& soap
         deb_println("[TR064][httpRequest] ---------------------------------", DEBUG_VERBOSE);
         deb_println(xml, DEBUG_VERBOSE);
         deb_println("[TR064][httpRequest] ---------------------------------\n", DEBUG_VERBOSE);
- 
+
         httpCode = http.POST(xml);
         deb_println("[TR064][httpRequest] POST... SOAPACTION: '" + soapaction + "'", DEBUG_VERBOSE);
-    } else { 
+    } else {
         httpCode = http.GET();
         deb_println("[TR064][httpRequest] GET...", DEBUG_VERBOSE);
     }
@@ -683,7 +683,7 @@ bool TR064::xmlTakeParam(String (*params)[2], int nParam) {
 /**************************************************************************/
 bool TR064::xmlTakeParam(String& value, const String& needParam) {
     WiFiClient * stream = tr064ClientPtr;
-    while(stream->connected()) {       
+    while(stream->connected()) {
         if(!http.connected()) {
             deb_println("[TR064][xmlTakeParam] http connection lost", DEBUG_INFO);
             return false;                      

--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -147,7 +147,7 @@ void TR064::initServiceURLs() {
      */
 
     _state = TR064_NO_SERVICES;
-    if(httpRequest(_detectPage, "", "", true, _protocol))
+    if(httpRequest(_detectPage, "", "", true))
         {
             deb_println("[TR064][initServiceURLs] get the Stream ", DEBUG_INFO);
             int i = 0;
@@ -485,19 +485,19 @@ String TR064::findServiceURL(const String& service) {
     @return success state.
 */
 /**************************************************************************/
-bool TR064::httpRequest(const String& url, const String& xml, const String& soapaction, bool retry, Protocol protocol) {
+bool TR064::httpRequest(const String& url, const String& xml, const String& soapaction, bool retry) {
     if (url=="") {
         deb_println("[TR064][httpRequest] URL is empty, abort http request.", DEBUG_INFO);
         return false;
     }
 
-    String protocolPrefix = protocol == Protocol::useHttps ? "https://" : "http://";
-    bool useTls = protocol == Protocol::useHttps ? true : false;
+    String protocolPrefix = _protocol == Protocol::useHttps ? "https://" : "http://";
+    bool useTls = _protocol == Protocol::useHttps ? true : false;
 
     deb_println("[HTTP] prepare request to URL: " + protocolPrefix + _ip + ":" + _port + url, DEBUG_INFO);
     http.setReuse(true);
 
-    if (protocol == Protocol::useHttps) {
+    if (_protocol == Protocol::useHttps) {
         http.begin(tr064SslClient, _ip.c_str(), _port, url.c_str(), useTls);
         http.setConnectTimeout(2000);
     }else{

--- a/src/tr064.h
+++ b/src/tr064.h
@@ -113,11 +113,11 @@ class TR064 {
 
         bool action(const String& service, const String& act, String params[][2] = {}, int nParam = 0,const String& url = "");
         bool action(const String& service, const String& act, String params[][2], int nParam, String (*req)[2], int nReq, const String& url = "");
-        
+
         String md5String(const String& s);
         String byte2hex(byte number);
         int debug_level; ///< Available levels are `DEBUG_NONE`, `DEBUG_ERROR`, `DEBUG_WARNING`, `DEBUG_INFO`, and `DEBUG_VERBOSE`.
-       
+
     private:
         WiFiClient tr064SimpleClient;
         WiFiClientSecure tr064SslClient;
@@ -129,14 +129,14 @@ class TR064 {
         void initServiceURLs();
         void deb_print(const String& message, int level);
         void deb_println(const String& message, int level);
-        bool action_raw(const String& service,const String& act, String params[][2], int nParam, const String& url = "");               
+        bool action_raw(const String& service,const String& act, String params[][2], int nParam, const String& url = "");            
         bool httpRequest(const String& url, const String& xml, const String& action, bool retry);
         String generateAuthToken();
         String generateAuthXML();
         String findServiceURL(const String& service);
         String cleanOldServiceName(const String& service);
         bool xmlTakeParam(String (*params)[2], int nParam);
-        bool xmlTakeParam(String& value, const String& needParam);       
+        bool xmlTakeParam(String& value, const String& needParam);
         static String errorToString(int error);
 
         int _state;

--- a/src/tr064.h
+++ b/src/tr064.h
@@ -49,6 +49,7 @@ typedef enum {
 
 typedef enum {
       useHttp,
+      useHttpsInsec,
       useHttps
   } Protocol;
 

--- a/src/tr064.h
+++ b/src/tr064.h
@@ -47,12 +47,14 @@ typedef enum {
      TR064_CODE_SECONDFACTORAUTHBUSY = 868, // (“second factorauthentication busy”) will be returned and the 2FA procedure    
 } t_tr064_codes;
 
+/** Types of http protocol */
 typedef enum {
       useHttp,
       useHttpsInsec,
       useHttps
   } Protocol;
 
+/** X509Certificate */
 typedef const char* X509Certificate;
 
 #define arr_len( x )  ( sizeof( x ) / sizeof( *x ) ) ///< Gives the length of an array

--- a/src/tr064.h
+++ b/src/tr064.h
@@ -17,22 +17,18 @@
  *
  */
 
-
-
 #ifndef tr064_h
 #define tr064_h
 
 #include "Arduino.h"
 #include <MD5Builder.h>
+
 #if defined(ESP8266)
     //if(Serial) Serial.println(F("Version compiled for ESP8266."));
-    #include <ESP8266WiFi.h>
     #include <ESP8266HTTPClient.h>
 #elif defined(ESP32)
     //if(Serial) Serial.println(F("Version compiled for ESP32."));
-    #include <WiFi.h>
     #include <HTTPClient.h>
-
 #else
     //INCOMPATIBLE!
 #endif
@@ -49,21 +45,18 @@ typedef enum {
      TR064_CODE_SECONDFACTORAUTHBUSY = 868, // (“second factorauthentication busy”) will be returned and the 2FA procedure    
 } t_tr064_codes;
 
+typedef enum {
+      useHttp,
+      useHttps
+  } Protocol;
 
+typedef const char* X509Certificate;
 
 #define arr_len( x )  ( sizeof( x ) / sizeof( *x ) ) ///< Gives the length of an array
 
 // Possible values for client.state()
 #define TR064_NO_SERVICES           -1 ///< No Service actions will not execute
 #define TR064_SERVICES_LOADED       0 ///< Service loaded
-
-// Possible values for client.state()
-#define TR064_NO_SERVICES           -1
-#define TR064_SERVICES_LOADED       0
-
-// Possible values for client.state()
-#define TR064_NO_SERVICES          -1
-#define TR064_SERVICES_LOADED       0
 
 /**************************************************************************/
 /*! 
@@ -73,7 +66,7 @@ typedef enum {
 */
 /**************************************************************************/
 
-class TR064 {
+class TR064 { 
     public:
         /*!  Different debug level
          *   DEBUG_NONE         ///< Print no debug messages whatsoever
@@ -102,56 +95,59 @@ class TR064 {
         } ;
 
         TR064();
-        TR064(uint16_t port, const String& ip, const String& user, const String& pass);
+        TR064(uint16_t port, const String& ip, const String& user, const String& pass, Protocol protocol = Protocol::useHttp, X509Certificate pCertificate = nullptr);
         ~TR064() {}
-        TR064& setServer(uint16_t port, const String& ip, const String& user, const String& pass);
+        TR064& setServer(uint16_t port, const String& ip, const String& user, const String& pass, Protocol protocol, X509Certificate certificate);
         void init();
-        int state();       
-        
-        bool action(const String& service, const String& act, String params[][2] = {}, int nParam = 0,const String& url = "");
-        //bool action(const String& service, const String& act, String params[][2], int nParam, const String& url = "");
-        bool action(const String& service, const String& act, String params[][2], int nParam, String (*req)[2], int nReq, const String& url = "");
+        int state();
 
+        bool action(const String& service, const String& act, String params[][2] = {}, int nParam = 0,const String& url = "");
+        bool action(const String& service, const String& act, String params[][2], int nParam, String (*req)[2], int nReq, const String& url = "");
+        
         String md5String(const String& s);
-        String byte2hex(byte number);        
+        String byte2hex(byte number);
         int debug_level; ///< Available levels are `DEBUG_NONE`, `DEBUG_ERROR`, `DEBUG_WARNING`, `DEBUG_INFO`, and `DEBUG_VERBOSE`.
-         
+       
     private:
-        WiFiClient tr064client;
+        WiFiClient tr064SimpleClient;
+        WiFiClientSecure tr064SslClient;
+        WiFiClient * tr064ClientPtr;
         HTTPClient http;
-        
-        //TODO: More consistent naming
-        
+
+        //TODO: More consistent naming.
+
         void initServiceURLs();
         void deb_print(const String& message, int level);
         void deb_println(const String& message, int level);
-        bool action_raw(const String& service,const String& act, String params[][2], int nParam, const String& url = "");
-        bool httpRequest(const String& url,  const String& xml, const  String& action, bool retry);
+        bool action_raw(const String& service,const String& act, String params[][2], int nParam, const String& url = "");               
+        bool httpRequest(const String& url, const String& xml, const String& action, bool retry, Protocol protocol = Protocol::useHttp);
         String generateAuthToken();
         String generateAuthXML();
         String findServiceURL(const String& service);
         String cleanOldServiceName(const String& service);
         bool xmlTakeParam(String (*params)[2], int nParam);
-        bool xmlTakeParam(String& value, const String& needParam);
-        static String errorToString(int error);
+        bool xmlTakeParam(String& value, const String& needParam);       
+        String errorToString(int error);
 
         int _state;
         String _ip;
-        uint16_t _port;
+        int _port;
         String _user;
         String _pass;
-        String _realm; // To be requested from the router
-        String _secretH; // To be generated
+        String _realm; //To be requested from the router
+        String _secretH; //to be generated
         String _nonce = "";
         String _status;
+        X509Certificate _certificate;
+        Protocol _protocol;
 
         const char* const _requestStart = "<?xml version=\"1.0\"?><s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">";
         const char* const _detectPage = "/tr64desc.xml";
         const char* const _servicePrefix = "urn:dslforum-org:service:";
         unsigned long lastOutActivity;
         unsigned long lastInActivity;
-        /* 
-    		* TODO: We should give access to this data for users to inspect the
+        /*
+            * TODO: We should give access to this data for users to inspect the
         * possibilities of their device(s) - see #9 on Github.
         * TODO: Remove 100 services limits here
         */

--- a/src/tr064.h
+++ b/src/tr064.h
@@ -157,7 +157,7 @@ class TR064 {
         unsigned long lastOutActivity;
         unsigned long lastInActivity;
         /*
-                * TODO: We should give access to this data for users to inspect the
+        * TODO: We should give access to this data for users to inspect the
         * possibilities of their device(s) - see #9 on Github.
         * TODO: Remove 100 services limits here
         */

--- a/src/tr064.h
+++ b/src/tr064.h
@@ -76,7 +76,7 @@ typedef const char* X509Certificate;
 */
 /**************************************************************************/
 
-class TR064 { 
+class TR064 {
     public:
         /*!  Different debug level
          *   DEBUG_NONE         ///< Print no debug messages whatsoever
@@ -124,7 +124,7 @@ class TR064 {
         WiFiClient * tr064ClientPtr;
         HTTPClient http;
 
-        //TODO: More consistent naming.
+        //TODO: More consistent naming
 
         void initServiceURLs();
         void deb_print(const String& message, int level);
@@ -137,15 +137,15 @@ class TR064 {
         String cleanOldServiceName(const String& service);
         bool xmlTakeParam(String (*params)[2], int nParam);
         bool xmlTakeParam(String& value, const String& needParam);       
-        String errorToString(int error);
+        static String errorToString(int error);
 
         int _state;
         String _ip;
-        int _port;
+        uint16_t _port;
         String _user;
         String _pass;
-        String _realm; //To be requested from the router
-        String _secretH; //to be generated
+        String _realm; // To be requested from the router
+        String _secretH; // To be generated
         String _nonce = "";
         String _status;
         X509Certificate _certificate;
@@ -157,7 +157,7 @@ class TR064 {
         unsigned long lastOutActivity;
         unsigned long lastInActivity;
         /*
-            * TODO: We should give access to this data for users to inspect the
+                * TODO: We should give access to this data for users to inspect the
         * possibilities of their device(s) - see #9 on Github.
         * TODO: Remove 100 services limits here
         */

--- a/src/tr064.h
+++ b/src/tr064.h
@@ -25,9 +25,11 @@
 
 #if defined(ESP8266)
     //if(Serial) Serial.println(F("Version compiled for ESP8266."));
+    #include <ESP8266WiFi.h>
     #include <ESP8266HTTPClient.h>
 #elif defined(ESP32)
     //if(Serial) Serial.println(F("Version compiled for ESP32."));
+    #include <WiFi.h>
     #include <HTTPClient.h>
 #else
     //INCOMPATIBLE!
@@ -57,6 +59,14 @@ typedef const char* X509Certificate;
 // Possible values for client.state()
 #define TR064_NO_SERVICES           -1 ///< No Service actions will not execute
 #define TR064_SERVICES_LOADED       0 ///< Service loaded
+
+// Possible values for client.state()
+#define TR064_NO_SERVICES           -1
+#define TR064_SERVICES_LOADED       0
+
+// Possible values for client.state()
+#define TR064_NO_SERVICES          -1
+#define TR064_SERVICES_LOADED       0
 
 /**************************************************************************/
 /*! 

--- a/src/tr064.h
+++ b/src/tr064.h
@@ -130,7 +130,7 @@ class TR064 {
         void deb_print(const String& message, int level);
         void deb_println(const String& message, int level);
         bool action_raw(const String& service,const String& act, String params[][2], int nParam, const String& url = "");               
-        bool httpRequest(const String& url, const String& xml, const String& action, bool retry, Protocol protocol = Protocol::useHttp);
+        bool httpRequest(const String& url, const String& xml, const String& action, bool retry);
         String generateAuthToken();
         String generateAuthXML();
         String findServiceURL(const String& service);


### PR DESCRIPTION
This PR (for Esp32) adds the ability to use secure transmission with and without rootCa validation. The examples were adapted to show how secure transmission can be achieved. The changed library should be compatible to former versions for the Esp32.