### PR TITLE
WiFiClient -> 3.1.1 esp8266

### DIFF
--- a/src/tr064.cpp
+++ b/src/tr064.cpp
@@ -394,8 +394,9 @@ String TR064::httpRequest(String url, String xml, String soapaction) {
 String TR064::httpRequest(String url, String xml, String soapaction, bool retry) {
     deb_println("[HTTP] prepare request to URL: http://" + _ip + ":" + _port + url, DEBUG_INFO);
     
+    static WiFiClient wifi;
     HTTPClient http;
-    http.begin(_ip, _port, url);
+    http.begin(wifi, _ip, _port, url);
     if (soapaction != "") {
         http.addHeader("CONTENT-TYPE", "text/xml"); //; charset=\"utf-8\"
         http.addHeader("SOAPACTION", soapaction);


### PR DESCRIPTION
Makes Tag 1.1.0 compiling and working (only tested dial assistant) with 3.1.1 esp8266.
I couldn't get the newer versions working, several issues, while 1.1.0 still does fine.